### PR TITLE
Add cc_limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ passthrough assigns some midi routing settings for each connected midi device in
 - `Quantize midi` wraps note data to scales (quantization is set per connected midi device, so different scales can be used if desired)
 - `Root` sets the root note of the current scale
 - `Scale` sets the scale type (Major, Minor.. )
-- `CC limit` sets the limit of midi CC messages to be sent for every channel per `25ms` timeframe. if more messages than this limit are received, then the last messages (per channel) will be sent automatically on next timeframe. this is useful when a midi controller is generating too many messages too fast (eg. moving all the faders at once on a novation launchcontrol xl)
+- `CC limit` sets the limit of midi CC messages to be sent for every channel per `25ms` timeframe. if more messages than this limit are received, then the last messages (per channel) will be sent automatically on next timeframe. this is useful when a midi controller is generating too many messages too fast (eg. moving all the faders at once on a novation launchcontrol xl). the `Pass all` option allows all CC messages to passthrough, without any kind of limiting. the `Pass none` option doesn't allow any midi CC messages to passthrough, effectively removing all of them
 
 additionally, `Midi panic` is a toggle to stop all active notes if some notes are hanging.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ passthrough assigns some midi routing settings for each connected midi device in
 - `Quantize midi` wraps note data to scales (quantization is set per connected midi device, so different scales can be used if desired)
 - `Root` sets the root note of the current scale
 - `Scale` sets the scale type (Major, Minor.. )
+- `CC limit` sets the limit of midi CC messages to be sent for every channel per `25ms` timeframe. if more messages than this limit are received, then the last messages (per channel) will be sent automatically on next timeframe. this is useful when a midi controller is generating too many messages too fast (eg. moving all the faders at once on a novation launchcontrol xl)
 
 additionally, `Midi panic` is a toggle to stop all active notes if some notes are hanging.
 

--- a/lib/mod.lua
+++ b/lib/mod.lua
@@ -49,7 +49,8 @@ function write_state()
     io.write("send_clock="..v.send_clock..",")
     io.write("quantize_midi="..v.quantize_midi..",")
     io.write("current_scale="..v.current_scale..",")
-    io.write("root_note="..v.root_note.."}")
+    io.write("root_note="..v.root_note..",")
+    io.write("cc_limit="..v.cc_limit.."}")
   end
   io.write("}\n")
   io.close(f)
@@ -63,6 +64,10 @@ function read_state()
   end
 
   for i = 1, tab.count(state) do
+    if state[i].cc_limit == nil then
+      state[i].cc_limit = 1
+    end
+
     core.build_scale(state[i].root_note, state[i].current_scale, state[i].dev_port)
   end
 end
@@ -116,7 +121,8 @@ function create_config()
         send_clock = 1,
         quantize_midi = 1,
         current_scale = 1,
-        root_note = 0
+        root_note = 0,
+        cc_limit = 1
       }
     else
       state[v.port].dev_port = v.port
@@ -195,7 +201,13 @@ function create_config()
           action = function()
             core.build_scale(state[k].root_note, state[k].current_scale, k)
           end
-        }
+        },
+      cc_limit = {
+        param_type = "option",
+        id = "cc_limit",
+        name = "CC limit",
+        options = core.cc_limits
+      }
     }
 
     config[k].target.action(state[k].target)
@@ -220,6 +232,7 @@ function device_event(id, data)
         port_config.send_clock,
         port_config.quantize_midi,
         port_config.current_scale,
+        port_config.cc_limit,
         data)
       
       api.user_event(id, data)
@@ -277,7 +290,7 @@ local get_menu_pagination_table = function()
 end
 
 -- MOD MENU --
-local screen_order = {"active", "target", "input_channel", "output_channel", "send_clock", "quantize_midi", "root_note", "current_scale", "midi_panic"}
+local screen_order = {"active", "target", "input_channel", "output_channel", "send_clock", "quantize_midi", "root_note", "current_scale", "cc_limit", "midi_panic"}
 local m = {
   list=screen_order,
   pos=0,

--- a/lib/passthrough.lua
+++ b/lib/passthrough.lua
@@ -29,6 +29,7 @@ local function device_event(id, data)
       params:get("send_clock_"..port)==2,
       params:get("quantize_midi_"..port),
       params:get("current_scale_"..port),
+      params:get("cc_limit_"..port),
       data)
     
     Passthrough.user_event(id, data)
@@ -134,7 +135,12 @@ function Passthrough.init()
                 core.build_scale(params:get("root_note_"..v.port), params:get("current_scale_"..v.port), v.port)
               end
             }
-    
+          params:add {
+            type = "option",
+            id = "cc_limit_"..v.port,
+            name = "CC limit",
+            options = core.cc_limits
+          }
           end
           params:add_separator("All devices")
           params:add {

--- a/lib/passthrough.lua
+++ b/lib/passthrough.lua
@@ -49,7 +49,7 @@ function Passthrough.init()
   if core.has_devices == true then
 
       port_amount = tab.count(core.ports)
-      params:add_group("PASSTHROUGH", 9*port_amount + 2)
+      params:add_group("PASSTHROUGH", 10*port_amount + 2)
       
       for k, v in pairs(core.ports) do
           params:add_separator(v.port .. ': ' .. v.name)


### PR DESCRIPTION
Hi there!

I've added an `cc_limit` option.

The idea is to let only a maximum number of cc messages to pass in a fixed time window (25ms). If more cc messages are received then the script will keep the last value and send it automatically at the next time window start.

My issue is that I have a Novation Launchcontrol XL connected to norns. When I move all the faders fast at once then it will generate too many cc messages. I'm trying to limit the number of cc messages.

Hope it's clear enough what I'm trying to achieve (and why). And thanks for the good work!